### PR TITLE
Improve Promise Result rejected logs

### DIFF
--- a/eme_listeners.js
+++ b/eme_listeners.js
@@ -359,10 +359,10 @@ EmeListeners.extendEmeMethod = function(
     if (result && result.constructor.name == 'Promise') {
       var description = title + ' Promise Result';
       result = result.then(function(resultObject) {
-        EmeListeners.logPromiseResult(description, 'resolved', resultObject);
+        EmeListeners.logPromiseResult(description, 'resolved', resultObject, args);
         return Promise.resolve(resultObject);
       }).catch(function(error) {
-        EmeListeners.logPromiseResult(description, 'rejected', error);
+        EmeListeners.logPromiseResult(description, 'rejected', error, args);
         return Promise.reject(error);
       });
     }
@@ -412,9 +412,10 @@ EmeListeners.logEvent = function(event) {
  * @param {string} description A short description of this Promise.
  * @param {string} status The status of this Promise.
  * @param {Object} result The result of this Promise.
+ * @param {Object} args The arguments that were passed.
  */
-EmeListeners.logPromiseResult = function(description, status, result) {
-  var logOutput = new emePrototypes.PromiseResult(description, status, result);
+EmeListeners.logPromiseResult = function(description, status, result, args) {
+  var logOutput = new emePrototypes.PromiseResult(description, status, result, args);
   window.postMessage({data:
                       JSON.parse(JSON.stringify(logOutput.getMessageObject())),
                       type: 'emeLogMessage'}, '*');

--- a/eme_listeners.js
+++ b/eme_listeners.js
@@ -412,7 +412,7 @@ EmeListeners.logEvent = function(event) {
  * @param {string} description A short description of this Promise.
  * @param {string} status The status of this Promise.
  * @param {Object} result The result of this Promise.
- * @param {Object} args The arguments that were passed.
+ * @param {Array} args The arguments that were passed.
  */
 EmeListeners.logPromiseResult = function(description, status, result, args) {
   var logOutput = new emePrototypes.PromiseResult(description, status, result, args);

--- a/prototypes.js
+++ b/prototypes.js
@@ -181,12 +181,14 @@ emePrototypes.TargetElement = function(element) {
  * @param {string} description A description of the Promise.
  * @param {string} status Status of the Promise.
  * @param {Object} result The result of the Promise.
+ * @param {Object} args The arguments that were passed.
  * @constructor
  */
-emePrototypes.PromiseResult = function(description, status, result) {
+emePrototypes.PromiseResult = function(description, status, result, args) {
   this.description = description;
   this.status = status;
   this.result = result;
+  this.args = args;
 };
 
 
@@ -198,8 +200,9 @@ emePrototypes.PromiseResult = function(description, status, result) {
 emePrototypes.PromiseResult.prototype.getMessageObject = function() {
   var data = {
     title: this.description,
-    names: ['status', 'result'],
-    values: [this.status, emePrototypes.getMessagePassableObject(this.result)]
+    names: ['status', 'result', 'args'],
+    values: [this.status, emePrototypes.getMessagePassableObject(this.result),
+        emePrototypes.getMessagePassableObject(this.args)]
   };
   return data;
 };

--- a/prototypes.js
+++ b/prototypes.js
@@ -181,7 +181,7 @@ emePrototypes.TargetElement = function(element) {
  * @param {string} description A description of the Promise.
  * @param {string} status Status of the Promise.
  * @param {Object} result The result of the Promise.
- * @param {Object} args The arguments that were passed.
+ * @param {Array} args The arguments that were passed.
  * @constructor
  */
 emePrototypes.PromiseResult = function(description, status, result, args) {


### PR DESCRIPTION
This PR adds arguments that were passed to the Promise Result rejected logs.

Steps to reproduce:
1. Go to https://shaka-player-demo.appspot.com
2. Open DevTools and check logs
3. Try to tell which keySystem is not supported. We can't ;(

BEFORE:
```
emePrototypes.PromiseResult {...}
> description: "RequestMediaKeySystemAccessCall Promise Result"
> result: DOMException: Unsupported keySystem
> status: "rejected"
```

NOW:
```
emePrototypes.PromiseResult {...}
> args: (2) ["com.microsoft.playready", Array(2)]
> description: "RequestMediaKeySystemAccessCall Promise Result"
> result: DOMException: Unsupported keySystem
> status: "rejected"
```