### PR TITLE
Support EME logger in iframes

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,6 +7,7 @@
   "content_scripts": [{
     "matches": ["http://*/*", "https://*/*", "file://*"],
     "js": ["content_script.js"],
+    "all_frames": true,
     "run_at": "document_start"
   }],
   "icons": {


### PR DESCRIPTION
This change makes EME logger working with <video> in iframes. See https://developer.chrome.com/extensions/content_scripts#frames